### PR TITLE
switch language detection for now

### DIFF
--- a/mcextractor/languages.py
+++ b/mcextractor/languages.py
@@ -1,12 +1,13 @@
 from typing import Optional
-import cld2
+import py3langid as langid
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 def from_text(text: str) -> Optional[str]:
-    is_reliable, text_bytes_found, details = cld2.detect(text)
-    if is_reliable and len(details) > 0:
-        return details[0][1]
-    return None
+    try:
+        lang, prob = langid.classify(text)
+        return lang
+    except Exception as _:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dateparser
 tldextract
 
 # for languge detection
-cld2-cffi
+py3langid
 
 # various content extractors we try to use
 newspaper3k


### PR DESCRIPTION
Collaborators reported intalling cld2 library wrappers failed in containers, because it needs gcc to build cld2.