### PR TITLE
Use latest htmldate and pass datetime max_date instead of string

### DIFF
--- a/mcmetadata/dates.py
+++ b/mcmetadata/dates.py
@@ -11,9 +11,8 @@ logger = logging.getLogger(__name__)
 def guess_publication_date(html: str, url: str, max_date: Optional[dt.datetime] = None) -> Optional[dt.datetime]:
     pub_date = None
     try:
-        max_date_str = max_date.strftime('%Y-%m-%d') if max_date else None
         pub_date_str = htmldate.find_date(html, url=url, original_date=True, extensive_search=False,
-                                          max_date=max_date_str)
+                                          max_date=max_date)
         if pub_date_str:
             pub_date = dateparser.parse(pub_date_str)
             if max_date and (pub_date > max_date):  # double check for safety

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 
 REQUIRED_PACKAGES = [
     # for date guessing
-    "htmldate==1.2.*", "dateparser==1.1.*",
+    "htmldate==1.3.*", "dateparser==1.1.*",
     # for domain name and URL extraction
     "tldextract==3.3.*",
     "url-normalize==1.4.*",


### PR DESCRIPTION
The latest `htmldate` is more efficient https://github.com/adbar/htmldate/blob/master/CHANGELOG.md
Update to the latest.

`max_date` can be either a `str` or a `datetime` object.
Since we already have a `datetime` object, there is no point in making
it a string to pass it to `htmldate_find_date`