### PR TITLE
fix bugs from PT integration

### DIFF
--- a/mcmetadata/test/test_titles.py
+++ b/mcmetadata/test/test_titles.py
@@ -41,6 +41,26 @@ class TestTitle(unittest.TestCase):
             html_text, _ = webpages.fetch(url)
         assert titles.from_html(html_text) == expected_title
 
+    def test_title_pt(self):
+        self._fetch_and_validate(
+            "https://g1.globo.com/pi/piaui/noticia/2023/01/02/mulher-e-esfaqueada-pelo-ex-namorado-dentro-de-casa-no-sul-do-piaui.ghtml",
+            "Mulher é esfaqueada pelo ex-namorado dentro de casa no Sul do Piauí"
+        )
+
+    def test_pt_empty_h1(self):
+        # the h1 on this page is empty, so we should pick the title from other places
+        self._fetch_and_validate(
+            "https://www.band.uol.com.br/bandnews-fm/rio-de-janeiro/noticias/acusado-de-assassinar-namorada-a-facadas-tem-prisao-convertida-em-preventiva-16574059",
+            "Acusado de assassinar namorada a facadas tem prisão convertida em preventiva"
+        )
+
+    def test_pt_home_in_title_word(self):
+        # we try to remove "home" from titles, but "homem" is a PT word so make sure we don't remove that
+        self._fetch_and_validate(
+            "https://radioalianca.com.br/plantao/homem-de-24-anos-e-morto-por-golpes-de-faca-em-concordia-na-noite-de-quarta-feira",
+            "Homem de 24 anos é morto por golpes de faca em Concórdia na noite de quarta-feira"
+        )
+
     def test_meta_og_title(self):
         self._fetch_and_validate(
             "https://web.archive.org/web/https://www.indiatimes.com/explainers/news/united-nations-climate-report-means-for-india-wet-bulb-temperature-563318.html",

--- a/mcmetadata/titles.py
+++ b/mcmetadata/titles.py
@@ -22,7 +22,7 @@ h1_tag_pattern = re.compile(r"<h1(?: [^>]*)?>(.*?)</h1>", re.S | re.I)
 
 whitespace_pattern = re.compile(r'\s+')
 
-home_pattern = re.compile(r'^\W*home\W*', re.I)
+home_pattern = re.compile(r'^\W+home\W+', re.I)
 
 
 def from_html(html_text: str, fallback_title: str = None, trim_to_length: int = 0) -> Optional[str]:
@@ -92,7 +92,7 @@ def from_html(html_text: str, fallback_title: str = None, trim_to_length: int = 
     match = h1_tag_pattern.search(html_text)
     if match and len(match.groups()) == 1:
         h1_title = unescape(text.strip_tags(match.group(1))).strip()
-        if h1_title in title.strip():
+        if (len(h1_title) > SHORT_TITLE_THRESHOLD) and (h1_title in title.strip()):
             title = h1_title
 
     # optionally trim to a max length


### PR DESCRIPTION
Integration with PT language models in the feminicide detector revealed some new bugs - stories where the title was coming back empty and where the first part of the title was cutoff. I traced those through the systems to this metadata library and fixed them.