### PR TITLE
Support defaults and overrides in `extract`

### DIFF
--- a/mcmetadata/__init__.py
+++ b/mcmetadata/__init__.py
@@ -22,7 +22,7 @@ stats = {s: 0 for s in STAT_NAMES}
 
 
 def extract(url: str, html_text: Optional[str] = None, include_other_metadata: Optional[bool] = False,
-            defaults: Mapping[str, Any] = None, overrides: Mapping[str, Any] = None) -> Dict:
+            defaults: Mapping[str, Any] = {}, overrides: Mapping[str, Any] = {}) -> Dict:
     """
     The core method of this library - returns all the useful information extracted from the HTML of the next
     article at the supplied URL.
@@ -74,7 +74,7 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
     # pub date stuff
     t1 = time.time()
     max_pub_date = dt.datetime.now() + dt.timedelta(days=+MAX_FUTURE_PUB_DATE)
-    if overrides and ('publication_date' in overrides):
+    if 'publication_date' in overrides:
         pub_date = overrides['publication_date']
     else:
         default_date = defaults.get('publication_date') if defaults else None
@@ -84,7 +84,7 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
 
     # content
     t1 = time.time()
-    if overrides and ('text_content' in overrides):
+    if 'text_content' in overrides:
         article = dict(extraction_method = content.METHOD_OVERRIDEN,
                        text=overrides['text_content'])
     else:
@@ -94,7 +94,7 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
 
     # title
     t1 = time.time()
-    if overrides and ('article_title' in overrides):
+    if 'article_title' in overrides:
         article_title = overrides['article_title']
     else:
         article_title = titles.from_html(raw_html, article['title'])
@@ -106,7 +106,7 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
 
     # language
     t1 = time.time()
-    if overrides and ('language' in overrides):
+    if 'language' in overrides:
         full_language = overrides['language']
     else:
         full_language = languages.from_html(raw_html, article['text'])  # could be something like "pt-br"

--- a/mcmetadata/__init__.py
+++ b/mcmetadata/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Any, Mapping
 import logging
 import datetime as dt
 import time
@@ -21,7 +21,8 @@ STAT_NAMES = ['total', 'fetch', 'url', 'pub_date', 'content', 'title', 'language
 stats = {s: 0 for s in STAT_NAMES}
 
 
-def extract(url: str, html_text: Optional[str] = None, include_other_metadata: Optional[bool] = False) -> Dict:
+def extract(url: str, html_text: Optional[str] = None, include_other_metadata: Optional[bool] = False,
+            defaults: Mapping[str, Any] = None, overrides: Mapping[str, Any] = None) -> Dict:
     """
     The core method of this library - returns all the useful information extracted from the HTML of the next
     article at the supplied URL.
@@ -32,6 +33,13 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
     :param bool include_other_metadata: Pass in true to top_image, authors, and other things returned under an `other`
                                         property in the results. Warning - this can slow down extraction by around 5x.
                                         In addition, we haven't tested the robustness and accuracy of these at scale.
+    :param defaults: (optional) A dictionary of default values to use as fallback values if specific metadata can't
+                     be found. Keys should be the same as the keys in the returned dictionary (supports
+                     `publication_date`, `text_content`, `article_title`, and `language`).
+    :param overrides: (optional) A dictionary of values to use instead of trying to parse them out from the content.
+                     Keys should be the same as the keys in the returned dictionary (supports `publication_date`,
+                     `article_title`, and `language`). This can be useful for speed optimizations,
+                     since if an override is provided then that extraction method won't be called.
     """
     t0 = time.time()
     # first fetch the real content (if we need to)
@@ -66,26 +74,44 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
     # pub date stuff
     t1 = time.time()
     max_pub_date = dt.datetime.now() + dt.timedelta(days=+MAX_FUTURE_PUB_DATE)
-    pub_date = dates.guess_publication_date(raw_html, final_url, max_date=max_pub_date)
+    if overrides and ('publication_date' in overrides):
+        pub_date = overrides['publication_date']
+    else:
+        default_date = defaults.get('publication_date') if defaults else None
+        pub_date = dates.guess_publication_date(raw_html, final_url, max_date=max_pub_date, default_date=default_date)
     pub_date_duration = time.time() - t1
     stats['pub_date'] += pub_date_duration
 
     # content
     t1 = time.time()
-    article = content.from_html(final_url, raw_html, include_other_metadata)
+    if overrides and ('text_content' in overrides):
+        article = dict(extraction_method = content.METHOD_OVERRIDEN,
+                       text=overrides['text_content'])
+    else:
+        article = content.from_html(final_url, raw_html, include_other_metadata)
     content_duration = time.time() - t1
     stats['content'] += content_duration
 
     # title
     t1 = time.time()
-    article_title = titles.from_html(raw_html, article['title'])
+    if overrides and ('article_title' in overrides):
+        article_title = overrides['article_title']
+    else:
+        article_title = titles.from_html(raw_html, article['title'])
+        if article_title is None:
+            article_title = defaults.get('article_title') if defaults else None
     normalized_title = titles.normalize_title(article_title)
     title_duration = time.time() - t1
     stats['title'] += title_duration
 
     # language
     t1 = time.time()
-    full_language = languages.from_html(raw_html, article['text'])  # could be something like "pt-br"
+    if overrides and ('language' in overrides):
+        full_language = overrides['language']
+    else:
+        full_language = languages.from_html(raw_html, article['text'])  # could be something like "pt-br"
+        if full_language is None:
+            full_language = defaults.get('language') if defaults else None
     language_duration = time.time() - t1
     stats['language'] += language_duration
 
@@ -111,10 +137,10 @@ def extract(url: str, html_text: Optional[str] = None, include_other_metadata: O
     if include_other_metadata:
         # other metadata we've done less robust validation on, but might be useful
         results['other'] = dict(
-            raw_title=article['title'],
-            raw_publish_date=article['potential_publish_date'],
-            top_image_url=article['top_image_url'],
-            authors=article['authors'],
+            raw_title=article['title'] if 'title' in article else None,
+            raw_publish_date=article['potential_publish_date'] if 'potential_publish_date' in article else None,
+            top_image_url=article['top_image_url'] if 'top_image_url' in article else None,
+            authors=article['authors'] if 'authors' in article else None,
         )
 
     return results

--- a/mcmetadata/content.py
+++ b/mcmetadata/content.py
@@ -35,8 +35,9 @@ METHOD_BEAUTIFUL_SOUP_4 = 'beautifulsoup4'
 METHOD_BOILER_PIPE_3 = 'boilerpipe3'
 METHOD_READABILITY = 'readability'
 METHOD_TRAFILATURA = 'trafilatura'
-METHOD_LXML = "lxml"
+METHOD_LXML = 'lxml'
 METHOD_FAILED = 'failed'  # placeholder for stats
+METHOD_OVERRIDEN = 'overriden'
 
 # track stats on how frequently each method succeeds (keyed by the METHOD_XYZ constants)
 method_success_stats = collections.Counter()

--- a/mcmetadata/dates.py
+++ b/mcmetadata/dates.py
@@ -8,7 +8,8 @@ import htmldate
 logger = logging.getLogger(__name__)
 
 
-def guess_publication_date(html: str, url: str, max_date: Optional[dt.datetime] = None) -> Optional[dt.datetime]:
+def guess_publication_date(html: str, url: str, max_date: Optional[dt.datetime] = None,
+                           default_date: Optional[dt.datetime] = None) -> Optional[dt.datetime]:
     pub_date = None
     try:
         pub_date_str = htmldate.find_date(html, url=url, original_date=True, extensive_search=False,
@@ -21,4 +22,6 @@ def guess_publication_date(html: str, url: str, max_date: Optional[dt.datetime] 
     except:
         # if there is no date found, or it is in a format that can't be parsed, ignore and just keep going
         logger.error('Publication date parsing failed', exc_info=1)
+    if (pub_date is None) and (default_date is not None):
+        pub_date = default_date
     return pub_date

--- a/mcmetadata/test/test_dates.py
+++ b/mcmetadata/test/test_dates.py
@@ -36,6 +36,16 @@ class TestDates(unittest.TestCase):
     def tearDown(self):
         time.sleep(1)  # sleep time in seconds
 
+    def _get_html(self, url: str) -> str:
+        if self.use_cache:
+            try:
+                raw_html = read_fixture(filesafe_url(url))
+            except:
+                raw_html, _ = webpages.fetch(url, timeout=120)
+        else:
+            raw_html, _ = webpages.fetch(url, timeout=120)
+        return raw_html
+
     @parameterized.expand([
         # subhead
         ("https://web.archive.org/web/https://www.sun-sentinel.com/community/fl-cn-calendar-events-20211201-20211129-sv3syeeuwzeallnr4vcanvaeti-story.html", dt.date(2021, 11, 29)),
@@ -58,16 +68,7 @@ class TestDates(unittest.TestCase):
         ("http://www.diariobahiadecadiz.com/noticias/san-fernando/cavada-y-romero-mantienen-otro-encuentro-con-defensa-para-negociar-la-desafectacion-de-suelo-en-camposoto-requerira-un-tiempo-indeterminado/", dt.date(2016, 10, 13))
     ])
     def test_pub_date(self, url, expected_date):
-        
-        if(self.use_cache):
-            try:
-                raw_html = read_fixture(filesafe_url(url))
-            except:
-                raw_html, _ = webpages.fetch(url, timeout=120)
-        else:
-            raw_html, _ = webpages.fetch(url, timeout=120)
-
-        
+        raw_html = self._get_html(url)
         pub_date = dates.guess_publication_date(raw_html, url)
         if expected_date is None:
             assert pub_date is None
@@ -81,3 +82,11 @@ class TestDates(unittest.TestCase):
         assert date.date() == dt.date(2022, 7, 17)
         date = dates.guess_publication_date(raw_html, u, max_date=dt.datetime(2020, 1, 1))
         assert date is None
+
+    def test_default_date(self):
+        undateable_url = "http://archive.org"
+        raw_html = self._get_html(undateable_url)
+        pub_date = dates.guess_publication_date(raw_html, undateable_url)
+        assert pub_date is None
+        pub_date = dates.guess_publication_date(raw_html, undateable_url, default_date=dt.datetime(2023, 1, 1))
+        assert pub_date == dt.datetime(2023, 1, 1)

--- a/mcmetadata/test/test_extract.py
+++ b/mcmetadata/test/test_extract.py
@@ -110,10 +110,13 @@ class TestExtract(unittest.TestCase):
         assert len(results['other']['authors']) == 1
 
     def test_whitespace_removal(self):
+        previous_min_content_length = content.MINIMUM_CONTENT_LENGTH
+        content.MINIMUM_CONTENT_LENGTH = 10
         url = "https://observador.vsports.pt/embd/75404/m/9812/obsrv/53a58b677b53143428e47d43d5887139?autostart=false"
         results = extract(url, include_other_metadata=True)
         # the point here is that it removes all pre and post whitespace - tons of junk
         assert len(results['text_content']) == 110
+        content.MINIMUM_CONTENT_LENGTH = previous_min_content_length
 
     def test_memento_without_original_url(self):
         try:

--- a/mcmetadata/test/test_extract.py
+++ b/mcmetadata/test/test_extract.py
@@ -123,6 +123,47 @@ class TestExtract(unittest.TestCase):
         except BadContentError:
             assert True
 
+    def test_overrides(self):
+        url = "https://www.indiatimes.com/news/india/75th-independence-day-india-august-15-576959.html"
+        overrides = dict(
+            text_content="This is some text",
+            article_title="This is a title",
+            language="pt",
+            publication_date=dt.date(2023, 1, 1)
+        )
+        # validate not the same as overrides
+        results = extract(url)
+        assert results['text_content'] != overrides['text_content']
+        assert results['article_title'] != overrides['article_title']
+        assert results['language'] != overrides['language']
+        assert results['publication_date'] != overrides['publication_date']
+        # now use overrides and validate they are changed
+        results = extract(url, overrides=overrides)
+        assert results['text_content'] == overrides['text_content']
+        assert results['article_title'] == overrides['article_title']
+        assert results['language'] == overrides['language']
+        assert results['publication_date'] == overrides['publication_date']
+
+    def test_default_title(self):
+        # throws too short error if no default
+        url = "https://web.archive.org/web/20111013162600id_/http://www.azftf.gov/(F(r8GSI1MAawoG8fkwp0vWYNSTuweOi8-9wgJOr4j83rTcpZDuFOV5E2PG737tNitGhzYAsUmVcwVEcgwKEtYFADTmzsQMJto9bZTOzDBHUGRpirFPIt4osB08CAslzBk-ih5ATrsM-P7DRxDwcNdmfB4jU1Y1))/WhatWeDo/Volunteer/Pages/default.aspx"
+        results = extract(url)
+        assert results['article_title'] is None
+        # verify throws too short error
+        defaults = dict(article_title="This is a title")
+        results = extract(url, defaults=defaults)
+        assert results['article_title'] == defaults['article_title']
+
+    def test_default_pub_date(self):
+        html = "<html><body>sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf sdf asdf asfewaf lkjl;kjf ;iasjfoijfésadsf</body></html>"
+        # verify can't guess date
+        results = extract("https://www.example.com", html_text=html)
+        assert results['publication_date'] is None
+        # now with default
+        defaults = dict(publication_date=dt.datetime(2023, 2, 1))
+        results = extract("https://www.example.com", html_text=html, defaults=defaults)
+        assert results['publication_date'] == defaults['publication_date']
+
 
 class TestStats(unittest.TestCase):
 

--- a/mcmetadata/test/test_urls.py
+++ b/mcmetadata/test/test_urls.py
@@ -41,6 +41,15 @@ class TestCanonicalDomain(unittest.TestCase):
 
 class TestNormalizeUrl(unittest.TestCase):
 
+    def test_ref_removal(self):
+        normalized = "http://upstract.com/x/fdf95bf448e1f2a8"
+        url = "https://upstract.com/x/fdf95bf448e1f2a8"
+        normalized_url = urls.normalize_url(url)
+        assert normalized_url == normalized
+        url = "https://upstract.com/x/fdf95bf448e1f2a8?ref=rss"
+        normalized_url = urls.normalize_url(normalized)
+        assert normalized_url == normalized
+
     def test_reuters_example(self):
         url1 = "http://feeds.reuters.com/~r/reuters/topnews/~3/nachplxyqso/u-s-probes-border-patrol-as-criticism-of-detention-centers-rises-iduskcn1ty1a5"
         normalized_url1 = urls.normalize_url(url1)

--- a/mcmetadata/test/test_webpages.py
+++ b/mcmetadata/test/test_webpages.py
@@ -32,9 +32,13 @@ class TestFetch(unittest.TestCase):
         except requests.exceptions.ConnectionError:
             assert True
 
-    def test_empty(self):
+    def test_bad_response(self):
         url = "https://uionline.detma.org/static/glossary.aspx?term=WHYOPTPMTTWOWAIVERRQSTS"
-        _, _ = webpages.fetch(url)
+        try:
+            _, _ = webpages.fetch(url) # raises a 403
+            assert False
+        except RuntimeError:
+            assert True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds support for sending in default and override values for _some_ properties coming into extract. Includes unit tests and docstrings describing support.