### PR TITLE
Add version constraint caution for Trafilatura

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,12 @@ dependencies = [
     # for language detection
     "py3langid==0.2.*",
     # various content extractors we try to use
-    "newspaper3k==0.2.*", "goose3==3.1.*", "BeautifulSoup4==4.12.*", "readability-lxml==0.8.*",
-    "trafilatura==1.8.*", "boilerpy3==1.0.*",
+    "newspaper3k==0.2.*",
+    "goose3==3.1.*",
+    "BeautifulSoup4==4.12.*",
+    "readability-lxml==0.8.*",
+    "trafilatura==1.8.*", # must stay below v1.11.* to allow easy extraction of canonical_url
+    "boilerpy3==1.0.*",
     # support
     "requests",         # leave un-versioned so dependencies can sort of which version is best
     "faust-cchardet==2.1.*",  # BeautifulSoup4 speedup


### PR DESCRIPTION
This PR adds a comment on the dependency constraint for `Trafilatura` library. While there is an in-code warning, on why we shouldn't upgrade to [v1.11.*](https://github.com/adbar/trafilatura/releases/tag/v1.11.0) or later, adding this constraint in `pyproject.toml` increases visibility, as recommended in #99.
