### PR TITLE
fix and test top_image for default trafilatura extract case #107

### DIFF
--- a/mcmetadata/content.py
+++ b/mcmetadata/content.py
@@ -198,7 +198,7 @@ class TrafilaturaExtractor(AbstractExtractor):
                 "url"
             ],  # Warning: This will not work with Trafilatura v1.11.* and later
             "potential_publish_date": dateparser.parse(results["date"]),
-            "top_image_url": image_urls[0] if len(image_urls) > 0 else None,
+            "top_image_url": image_urls[0] if len(image_urls) > 0 else results["image"],
             "authors": results["author"].split(",") if results["author"] else None,
             "extraction_method": METHOD_TRAFILATURA,
         }

--- a/mcmetadata/test/test_content.py
+++ b/mcmetadata/test/test_content.py
@@ -16,6 +16,18 @@ def use_cache(pytestconfig):
     return pytestconfig.getoption("--use-cache")
 
 
+class TestContentMetadata(unittest.TestCase):
+    URL = "https://www.nbcnews.com/health/health-news/rfk-jrs-cdc-panel-discuss-covid-vaccine-injuries-upcoming-meeting-rcna260694"
+    EXPRECTED_IMG_URL = "https://media-cldnry.s-nbcnews.com/image/upload/t_nbcnews-fp-1200-630,f_auto,q_auto:best/rockcms/2026-02/260225-moderna-covid-vaccine-vl-312p-924ca2.jpg"
+
+    def test_top_image(self):
+        html_text, response = webpages.fetch(self.URL)
+        meta = content.from_html(self.URL, html_text, False)
+        assert meta["top_image_url"] == self.EXPRECTED_IMG_URL
+        meta = content.from_html(self.URL, html_text, True)
+        assert meta["top_image_url"] == self.EXPRECTED_IMG_URL
+
+
 # @pytest.mark.usefixtures("use_cache")
 class TestContentParsers(unittest.TestCase):
 


### PR DESCRIPTION
Very small fix to support a new workflow. It looks like perhaps the format of image fetching in Trafilatura changed and our code wasn't adapted? I fixed this and added a simple unit test for it. 
Small note: wayback machine isn't performing well, so I left the test URL to be the full one, not through their archive.